### PR TITLE
fix: SQLAlchemy 예외 타입별 분기 추가 (#22)

### DIFF
--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -78,10 +78,36 @@ def map_sqlalchemy_error(
     code: str,
     context: Optional[dict[str, Any]] = None,
 ) -> AppError:
-    return AppError(
-        source="repository",
-        code=code,
-        message=str(error),
-        cause=error,
-        context=context,
-    )
+    from sqlalchemy.exc import IntegrityError, OperationalError, DataError
+    if isinstance(error, IntegrityError):
+        return AppError(
+            source="repository",
+            code="REPO/DUPLICATE",
+            message="중복된 데이터입니다.",
+            cause=error,
+            context=context,
+        )
+    elif isinstance(error, OperationalError):
+        return AppError(
+            source="repository",
+            code="REPO/DB_CONNECTION_ERROR",
+      베이 오류가 발생했습니다.",
+            cause=error,
+            context=context,
+        )
+    elif isinstance(error, DataError):
+        return AppError(
+            source="repository",
+            code="REPO/DATA_ERROR",
+            message="잘못된 데이터 형식입니다.",
+            cause=error,
+            context=context,
+        )
+    else:
+        return AppError(
+            source="repository",
+            code=code,
+            message=str(error),
+            cause=error,
+            context=context,
+        )


### PR DESCRIPTION
## 변경 사항
- `map_sqlalchemy_error` 함수에 SQLAlchemy 예외 타입별 분기 추가

## 상세 내용
기존에는 모든 DB 예외를 동일하게 처리했으나,
아래와 같이 타입별로 분기하여 더 명확한 에러 메시지를 반환하도록 개선

- `IntegrityError` → 중복 데이터 에러
- `OperationalError` → DB 연결 에러  
- `DataError` → 잘못된 데이터 형식 에러
- 그 외 → 기존 code 그대로 반환

## 관련 이슈
close #22