### PR TITLE
fix: ExamResult FK 제약 추가, 라우터 레이어 위반 수정, lifespan 마이그레이션 (#27)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,5 @@
+import logging
+from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request
 from app.routers import exam as exam_router
 from app.core.errors import AppError, get_display_message
@@ -5,7 +7,19 @@ from app.core.config import ALLOWED_ORIGINS
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 
-app = FastAPI(title="exam_maker")
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # 서버 시작 시
+    logger.info("exam_maker 서버 시작!")
+    yield
+    # 서버 종료 시
+    logger.info("exam_maker 서버 종료!")
+
+
+app = FastAPI(title="exam_maker", lifespan=lifespan)
 
 # CORS 설정
 app.add_middleware(
@@ -22,9 +36,7 @@ app.include_router(exam_router.router)
 ERROR_STATUS_MAP: dict[str, int] = {
     "NOT_FOUND": 404,
     "UNAUTHORIZED": 401,
-    "FORBIDDEN": 403,
-    "VALIDATION_ERROR": 422,
-    "DUPLICATE": 409,
+    "FORBTE": 409,
     "INTERNAL_ERROR": 500,
     "DB_CONNECTION_ERROR": 503,
     "DATA_ERROR": 400,
@@ -32,6 +44,8 @@ ERROR_STATUS_MAP: dict[str, int] = {
 
 
 def get_http_status(code: str) -> int:
+    # 슬래시 계층형 코드에서 마지막 세그먼트 추출
+    # 예: "REPO/EXAM/NOT_FOUND" → "NOT_FOUND" → 404
     last_segment = code.split("/")[-1]
     return ERROR_STATUS_MAP.get(last_segment, 400)
 
@@ -54,8 +68,3 @@ async def app_error_handler(request: Request, error: AppError):
 @app.get("/health")
 async def health_check():
     return {"status": "ok"}
-
-
-@app.on_event("startup")
-async def startup():
-    print("exam_maker 서버 시작!")

--- a/backend/app/models/exam.py
+++ b/backend/app/models/exam.py
@@ -1,5 +1,6 @@
-from sqlalchemy import Column, String, Text, DateTime, JSON
+from sqlalchemy import Column, String, Text, DateTime, JSON, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
 from app.models.base import Base
 from datetime import datetime, timezone
 import uuid
@@ -18,12 +19,21 @@ class ExamAnalysis(Base):
     analysis_result = Column(JSON, nullable=False)  # 상세 분석 예정으로 JSON 형식 저장
     created_at = Column(DateTime(timezone=True), default=utcnow)
 
+    # 관계 정의
+    exam_results = relationship("ExamResult", back_populates="analysis")
+
 
 # 시험 분석 결과 모델
 class ExamResult(Base):
     __tablename__ = "exam_result"
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    analysis_id = Column(UUID(as_uuid=True), nullable=False)
-    exam_content = Column(Text, nullable=False)
+    analysis_id = Column(
+        UUID(ae="CASCADE"),
+        nullable=False,
+    )
+    exam_content = Column(JSON, nullable=False)  # Text → JSON으로 통일
     created_at = Column(DateTime(timezone=True), default=utcnow)
+
+    # 관계 정의
+    analysis = relationship("ExamAnalysis", back_populates="exam_results")

--- a/backend/app/repositories/exam.py
+++ b/backend/app/repositories/exam.py
@@ -1,4 +1,3 @@
-import json
 from typing import Optional
 from sqlalchemy.orm import Session
 from app.models.exam import ExamAnalysis, ExamResult
@@ -36,8 +35,7 @@ def get_analysis(
         analysis = db.query(ExamAnalysis).filter(
             ExamAnalysis.id == analysis_id
         ).first()
-        if not analysis:
-            raise create_repo_error(
+        if not error(
                 code="REPO/EXAM/NOT_FOUND",
                 message="분석 결과를 찾을 수 없습니다.",
             )
@@ -72,13 +70,11 @@ def save_exam_result(
     try:
         exam_result = ExamResult(
             analysis_id=analysis_id,
-            exam_content=json.dumps(exam_content, ensure_ascii=False),
+            exam_content=exam_content,
         )
         db.add(exam_result)
         db.commit()
-        db.refresh(exam_result)
-        return exam_result
-    except AppError:
+       
         raise
     except Exception as e:
         db.rollback()

--- a/backend/app/routers/exam.py
+++ b/backend/app/routers/exam.py
@@ -1,4 +1,3 @@
-import json
 import io
 from typing import List
 from fastapi import APIRouter, UploadFile, File, Depends
@@ -20,34 +19,29 @@ async def analyze_exam(
     db: Session = Depends(get_db),
 ):
     pdf_bytes = await file.read()
-    pdf_text = exam_service.extract_pdf_text(pdf_bytes)
-    analysis = exam_service.analyze_exam_pattern(
+    # 라우터는 서비스만 호출 — PDF 추출은 서비스 내부에서 처리
+    analysis = exam_service.analyze_exam_from_pdf(
         db=db,
         school_name=school_name,
-        pdf_text=pdf_text,
+        pdf_bytes=pdf_bytes,
     )
     return {
         "success": True,
         "analysis_id": str(analysis.id),
-        "analysis_result": analysis.analysis_result if isinstance(analysis.analysis_result, dict) else json.loads(analysis.analysis_result),
-        "message": "기출 분석이 완료됐습니다.",
-    }
-
-
-# 시험 범위 본문 추출
-@router.post("/range")
+        "analysis_result": analysis.analysis_result,
+        .post("/range")
 async def extract_exam_range(
     files: List[UploadFile] = File(...),
 ):
-    all_text = ""
+    all_passages = {}
     for file in files:
         pdf_bytes = await file.read()
-        pdf_text = exam_service.extract_pdf_text(pdf_bytes)
-        all_text += f"\n\n{pdf_text}"
-    passages = exam_service.extract_passages(all_text)
+        # 라우터는 서비스만 호출 — PDF 추출은 서비스 내부에서 처리
+        passages = exam_service.extract_passages_from_pdf(pdf_bytes=pdf_bytes)
+        all_passages.update(passages)
     return {
         "success": True,
-        "passages": passages,
+        "passages": all_passages,
     }
 
 
@@ -75,9 +69,7 @@ async def generate_exam(
 @router.get("/{exam_id}/download")
 async def download_exam(
     exam_id: str,
-    db: Session = Depends(get_db),
-):
-    exam = exam_service.get_exam(
+(
         db=db,
         exam_id=exam_id,
     )

--- a/backend/app/services/exam.py
+++ b/backend/app/services/exam.py
@@ -7,12 +7,47 @@ from app.repositories import exam as exam_repository
 from app.prompts.exam import ANALYZE_SCHOOL_PROMPT, EXTRACT_PASSAGES_PROMPT, get_generate_exam_prompt
 from app.utils.pdf import extract_pdf_text
 
-client = anthropic.Anthropic(api_key=ANTHROPIC_API_KEY)
+
+def get_anthropic_client() -> anthropic.Anthropic:
+    return anthropic.Anthropic(api_key=ANTHROPIC_API_KEY)
 
 
 # JSON 코드블록 제거 유틸
 def clean_json_response(text: str) -> str:
     return text.replace("```json", "").replace("```", "").strip()
+
+
+# PDF 바이트에서 텍스트 추출 후 패턴 분석까지 수행 (라우터 진입점)
+def analyze_exam_from_pdf(
+    db: Session,
+    school_name: str,
+    pdf_bytes: bytes,
+) -> dict:
+    try:
+        pdf_text = extract_pdf_text(pdf_bytes)
+        return analyze_exam_pattern(db=db, school_name=school_name, pdf_text=pdf_text)
+    except Aprvice_error(
+            e,
+            code="SERVICE/EXAM/ANALYZE_FROM_PDF",
+            message="PDF 분석 중 오류가 발생했습니다.",
+        )
+
+
+# 시험 범위 PDF에서 지문 추출 (라우터 진입점)
+def extract_passages_from_pdf(
+    pdf_bytes: bytes,
+) -> dict:
+    try:
+        pdf_text = extract_pdf_text(pdf_bytes)
+        return extract_passages(pdf_text=pdf_text)
+    except AppError:
+        raise
+    except Exception as e:
+        handle_service_error(
+            e,
+            code="SERVICE/EXAM/EXTRACT_FROM_PDF",
+            message="PDF 지문 추출 중 오류가 발생했습니다.",
+        )
 
 
 # 시험 패턴 분석 함수
@@ -25,15 +60,9 @@ def analyze_exam_pattern(
         # DB에 이미 분석 결과 있으면 재활용 (캐싱)
         # 주의: 동일 학교명 기준 캐싱이므로 연도/버전 구분 없음 (의도된 동작)
         existing = exam_repository.get_analysis_by_school_name(
-            db=db,
-            school_name=school_name,
-        )
-        if existing:
-            return existing
+            db=db,           raise ValueError("PDF에서 텍스트를 추출할 수 없습니다.")
 
-        # PDF 텍스트가 비어있으면 비즈니스 예외 발생
-        if not pdf_text or not pdf_text.strip():
-            raise ValueError("PDF에서 텍스트를 추출할 수 없습니다.")
+        client = get_anthropic_client()
 
         # Claude Sonnet으로 출제 패턴 분석
         message = client.messages.create(
@@ -53,7 +82,6 @@ def analyze_exam_pattern(
             analysis_result=analysis_result,
         )
     except AppError:
-        # 레포에서 올라온 AppError는 재랩핑 없이 그대로 올림
         raise
     except Exception as e:
         handle_service_error(
@@ -63,14 +91,11 @@ def analyze_exam_pattern(
         )
 
 
-# 시험 범위 본문 추출 함수
-def extract_passages(
-    pdf_text: str,
-) -> dict:
-    try:
-        # PDF 텍스트가 비어있으면 비즈니스 예외 발생
+# 시험 범???스 예외 발생
         if not pdf_text or not pdf_text.strip():
             raise ValueError("PDF에서 텍스트를 추출할 수 없습니다.")
+
+        client = get_anthropic_client()
 
         # Claude Haiku로 순수 본문 추출 (듣기 제외)
         message = client.messages.create(
@@ -99,18 +124,14 @@ def generate_exam(
     db: Session,
     analysis_id: str,
     passages: dict,
-    options: dict,
-) -> dict:
-    try:
-        # 분석 결과 조회
-        analysis = exam_repository.get_analysis(
-            db=db,
-            analysis_id=analysis_id,
+    optio     analysis_id=analysis_id,
         )
 
         # 지문이 비어있으면 비즈니스 예외 발생
         if not passages:
             raise ValueError("시험 범위 지문이 없습니다.")
+
+        client = get_anthropic_client()
 
         # Claude Opus로 시험지 생성
         message = client.messages.create(
@@ -132,9 +153,7 @@ def generate_exam(
         # DB 저장
         return exam_repository.save_exam_result(
             db=db,
-            analysis_id=str(analysis.id),
-            exam_content=exam_content,
-        )
+            analys )
     except AppError:
         raise
     except Exception as e:

--- a/backend/tests/test_errors.py
+++ b/backend/tests/test_errors.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import MagicMock, patch
 from app.core.errors import (
     AppError,
     create_repo_error,
@@ -28,11 +29,7 @@ def test_get_display_message_with_slash_code():
 
 # get_display_message 알 수 없는 코드 테스트
 def test_get_display_message_unknown_code():
-    message = get_display_message("UNKNOWN/CODE")
-    assert message == "알 수 없는 오류가 발생했습니다."
-
-
-# handle_service_error AppError 재랩핑 방지 테스트
+    me지 테스트
 def test_handle_service_error_no_rewrap():
     original = AppError(
         source="repository",
@@ -62,5 +59,45 @@ def test_map_sqlalchemy_error_default():
         Exception("unknown error"),
         code="REPO/EXAM/GET_ANALYSIS",
     )
-    assert error.code == "REPO/EXAM/GET_ANALYSIS"
-    assert error.source == "repository"
+    a
+
+
+# 서비스 레이어 - 캐싱 동작 테스트
+def test_analyze_exam_pattern_returns_cached_result():
+    from app.services.exam import analyze_exam_pattern
+    from app.models.exam import ExamAnalysis
+    import uuid
+
+    mock_db = MagicMock()
+    mock_analysis = ExamAnalysis(
+        id=uuid.uuid4(),
+        school_name="테스트고등학교",
+        analysis_result={"pattern": "test"},
+    )
+
+    with patch(
+        "app.repositories.exam.get_analysis_by_school_name",
+        return_value=mock_analysis,
+    ):
+        result = analyze_exam_pattern(
+            db=mock_db,
+            school_name="테스트고등학교",
+            pdf_text="시험 내용",
+        )
+        assert result == mock_analysis
+
+
+# 서비스 레이어 - 빈 PDF 텍스트 예외 테스트
+def test_analyze_exam_pattern_raises_on_empty_pdf():
+    from app.services.exam import analyze_exam_pattern
+
+    mock_db = MagicMock()
+
+    with patch(
+        "app.repositories.exam.get_analysis_by_school_name",
+        return_value=Non(
+                db=mock_db,
+                school_name="테스트고등학교",
+                pdf_text="",
+            )
+        assert exc_info.value.source == "service"


### PR DESCRIPTION
## 변경 사항
- `ExamResult`에 `ForeignKey` 제약 추가 (DB 참조 무결성 보장)
- `exam_content` 컬럼 Text → JSON으로 통일
- 라우터 레이어 위반 수정 (`extract_pdf_text` 직접 호출 제거)
- 서비스에 `analyze_exam_from_pdf`, `extract_passages_from_pdf` 진입점 추가
- `on_event("startup")` → `lifespan` 컨텍스트 매니저로 마이그레이션
- `print` → `logging` 으로 교체
- `get_anthropic_client()` 팩토리 함수로 클라이언트 초기화 분리
- alembic 마이그레이션 파일 추가
- 서비스 레이어 단위 테스트 추가 (캐싱 동작, 빈 PDF 예외)

## 관련 이슈
close #27