### PR TITLE
fix: ExamResult analysis_id ForeignKey 구문 오류 수정 (#27)

### DIFF
--- a/backend/app/models/exam.py
+++ b/backend/app/models/exam.py
@@ -29,7 +29,8 @@ class ExamResult(Base):
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     analysis_id = Column(
-        UUID(as_uuidCADE"),
+        UUID(as_uuid=True),
+        ForeignKey("exam_analysis.id", ondelete="CASCADE"),
         nullable=False,
     )
     exam_content = Column(JSON, nullable=False)  # Text → JSON으로 통일


### PR DESCRIPTION
## 변경 사항
- `UUID(as_uuidCADE")` 구문 오류 수정 → `ForeignKey("exam_analysis.id", ondelete="CASCADE")` 정상 적용

## 관련 이슈
close #27