### PR TITLE
refactor: dependencies 개선, school_name 정규화 강화, String 길이 제한 (#48)

### DIFF
--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,11 +1,20 @@
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, Session
+from typing import Generator
 from app.core.config import DATABASE_URL
 
-engine = create_engine(DATABASE_URL)
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+# engine과 SessionLocal을 함수로 감싸서 import 시점에 DB 연결 방지
+# 테스트 환경에서 DATABASE_URL이 없어도 import 가능
+def get_engine():
+    return create_engine(DATABASE_URL)
 
-def get_db():
+
+def get_session_local():
+    return sessionmaker(autocommit=False, autoflush=False, bind=get_engine())
+
+
+def get_db() -> Generator[Session, None, None]:
+    SessionLocal = get_session_local()
     db = SessionLocal()
     try:
         yield db

--- a/backend/app/models/exam.py
+++ b/backend/app/models/exam.py
@@ -19,7 +19,7 @@ class ExamAnalysis(Base):
     )
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    school_name = Column(String, nullable=False)
+    school_name = Column(String(100), nullable=False)  # 길이 제한 추가
     analysis_result = Column(JSON, nullable=False)  # 상세 분석 예정으로 JSON 형식 저장
     created_at = Column(DateTime(timezone=True), default=utcnow)
 

--- a/backend/app/services/exam.py
+++ b/backend/app/services/exam.py
@@ -1,4 +1,5 @@
 import json
+import re
 import anthropic
 from sqlalchemy.orm import Session
 from app.core.config import ANTHROPIC_API_KEY
@@ -19,9 +20,11 @@ def clean_json_response(text: str) -> str:
 
 
 # 학교명 정규화 유틸
-# 대소문자, 공백 등 사용자 입력 불일치로 인한 캐시 미스 방지
+# - 앞뒤 공백 제거
+# - 내부 공백 단일화 (연속 공백 → 단일 공백)
+# - 예: "서울  고등학교 " → "서울 고등학교"
 def normalize_school_name(school_name: str) -> str:
-    return school_name.strip()
+    return re.sub(r'\s+', ' ', school_name).strip()
 
 
 # Claude API 응답을 JSON으로 안전하게 파싱
@@ -81,7 +84,7 @@ async def analyze_exam_pattern(
     pdf_text: str,
 ) -> ExamAnalysis:
     try:
-        # 학교명 정규화 (공백 제거 등)
+        # 학교명 정규화 (앞뒤 공백 제거, 내부 연속 공백 단일화)
         normalized_name = normalize_school_name(school_name)
 
         # DB에 이미 분석 결과 있으면 재활용

--- a/backend/migrations/versions/d3e4f5a6b7c8_add_school_name_length_limit.py
+++ b/backend/migrations/versions/d3e4f5a6b7c8_add_school_name_length_limit.py
@@ -1,0 +1,36 @@
+"""add school_name length limit
+
+Revision ID: d3e4f5a6b7c8
+Revises: c2d3e4f5a6b7
+Create Date: 2026-04-25 01:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'd3e4f5a6b7c8'
+down_revision: Union[str, Sequence[str], None] = 'c2d3e4f5a6b7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # school_name 컬럼 길이 제한 추가 (String → String(100))
+    op.alter_column(
+        'exam_analysis',
+        'school_name',
+        existing_type=sa.String(),
+        type_=sa.String(100),
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        'exam_analysis',
+        'school_name',
+        existing_type=sa.String(100),
+        type_=sa.String(),
+        existing_nullable=False,
+    )


### PR DESCRIPTION
## 변경 사항
- `dependencies.py` - `create_engine` 함수로 감싸서 import 시점 DB 연결 방지
- `normalize_school_name()` - 내부 연속 공백 단일화 추가 (`re.sub(r'\s+', ' ', ...)`)
- `ExamAnalysis.school_name` - `String` → `String(100)` 길이 제한 추가
- alembic 마이그레이션 파일 추가

## 관련 이슈
close #48