### PR TITLE
refactor: AsyncSession 전환 및 비동기 DB 레이어 구현 (#50)

### DIFF
--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,22 +1,36 @@
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker, Session
-from typing import Generator
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
+from typing import AsyncGenerator
 from app.core.config import DATABASE_URL
 
-# engine과 SessionLocal을 함수로 감싸서 import 시점에 DB 연결 방지
-# 테스트 환경에서 DATABASE_URL이 없어도 import 가능
+# PostgreSQL async URL로 변환 (postgresql:// → postgresql+asyncpg://)
+def get_async_database_url() -> str:
+    return DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://")
+
+
+# async engine 생성
 def get_engine():
-    return create_engine(DATABASE_URL)
+    return create_async_engine(
+        get_async_database_url(),
+        echo=False,
+    )
 
 
+# async session factory
 def get_session_local():
-    return sessionmaker(autocommit=False, autoflush=False, bind=get_engine())
+    return async_sessionmaker(
+        bind=get_engine(),
+        class_=AsyncSession,
+        autocommit=False,
+        autoflush=False,
+        expire_on_commit=False,
+    )
 
 
-def get_db() -> Generator[Session, None, None]:
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
     SessionLocal = get_session_local()
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
+    async with SessionLocal() as session:
+        try:
+            yield session
+        except Exception:
+            await session.rollback()
+            raise

--- a/backend/app/repositories/exam.py
+++ b/backend/app/repositories/exam.py
@@ -1,12 +1,13 @@
 from typing import Optional
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
 from app.models.exam import ExamAnalysis, ExamResult
 from app.core.errors import AppError, create_repo_error, map_sqlalchemy_error
 
 
 # 시험 패턴 분석 결과 저장
-def save_analysis(
-    db: Session,
+async def save_analysis(
+    db: AsyncSession,
     school_name: str,
     analysis_result: dict,
 ) -> ExamAnalysis:
@@ -16,25 +17,26 @@ def save_analysis(
             analysis_result=analysis_result,
         )
         db.add(analysis)
-        db.commit()
-        db.refresh(analysis)
+        await db.commit()
+        await db.refresh(analysis)
         return analysis
     except AppError:
         raise
     except Exception as e:
-        db.rollback()
+        await db.rollback()
         raise map_sqlalchemy_error(e, "REPO/EXAM/SAVE_ANALYSIS")
 
 
 # 시험 패턴 분석 결과 조회
-def get_analysis(
-    db: Session,
+async def get_analysis(
+    db: AsyncSession,
     analysis_id: str,
 ) -> ExamAnalysis:
     try:
-        analysis = db.query(ExamAnalysis).filter(
-            ExamAnalysis.id == analysis_id
-        ).first()
+        result = await db.execute(
+            select(ExamAnalysis).where(ExamAnalysis.id == analysis_id)
+        )
+        analysis = result.scalar_one_or_none()
         if not analysis:
             raise create_repo_error(
                 code="REPO/EXAM/NOT_FOUND",
@@ -48,14 +50,15 @@ def get_analysis(
 
 
 # 학교명으로 시험 패턴 분석 결과 조회
-def get_analysis_by_school_name(
-    db: Session,
+async def get_analysis_by_school_name(
+    db: AsyncSession,
     school_name: str,
 ) -> Optional[ExamAnalysis]:
     try:
-        return db.query(ExamAnalysis).filter(
-            ExamAnalysis.school_name == school_name
-        ).first()
+        result = await db.execute(
+            select(ExamAnalysis).where(ExamAnalysis.school_name == school_name)
+        )
+        return result.scalar_one_or_none()
     except AppError:
         raise
     except Exception as e:
@@ -63,8 +66,8 @@ def get_analysis_by_school_name(
 
 
 # 시험지 생성 결과 저장
-def save_exam_result(
-    db: Session,
+async def save_exam_result(
+    db: AsyncSession,
     analysis_id: str,
     exam_content: dict,
 ) -> ExamResult:
@@ -74,25 +77,26 @@ def save_exam_result(
             exam_content=exam_content,
         )
         db.add(exam_result)
-        db.commit()
-        db.refresh(exam_result)
+        await db.commit()
+        await db.refresh(exam_result)
         return exam_result
     except AppError:
         raise
     except Exception as e:
-        db.rollback()
+        await db.rollback()
         raise map_sqlalchemy_error(e, "REPO/EXAM/SAVE_RESULT")
 
 
 # 시험지 생성 결과 조회
-def get_exam_result(
-    db: Session,
+async def get_exam_result(
+    db: AsyncSession,
     exam_id: str,
 ) -> ExamResult:
     try:
-        exam = db.query(ExamResult).filter(
-            ExamResult.id == exam_id
-        ).first()
+        result = await db.execute(
+            select(ExamResult).where(ExamResult.id == exam_id)
+        )
+        exam = result.scalar_one_or_none()
         if not exam:
             raise create_repo_error(
                 code="REPO/EXAM/RESULT_NOT_FOUND",

--- a/backend/app/routers/exam.py
+++ b/backend/app/routers/exam.py
@@ -2,7 +2,7 @@ import io
 from typing import List
 from fastapi import APIRouter, UploadFile, File, Depends
 from fastapi.responses import StreamingResponse
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies import get_db
 from app.services import exam as exam_service
 from app.services.docx import create_exam_docx
@@ -16,10 +16,9 @@ router = APIRouter(prefix="/api/v1/exam", tags=["exam"])
 async def analyze_exam(
     school_name: str,
     file: UploadFile = File(...),
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_db),
 ):
     pdf_bytes = await file.read()
-    # 라우터는 서비스만 호출 — PDF 추출은 서비스 내부에서 처리
     analysis = await exam_service.analyze_exam_from_pdf(
         db=db,
         school_name=school_name,
@@ -41,7 +40,6 @@ async def extract_exam_range(
     all_passages = {}
     for file in files:
         pdf_bytes = await file.read()
-        # 라우터는 서비스만 호출 — PDF 추출은 서비스 내부에서 처리
         passages = await exam_service.extract_passages_from_pdf(pdf_bytes=pdf_bytes)
         all_passages.update(passages)
     return {
@@ -55,7 +53,7 @@ async def extract_exam_range(
 async def generate_exam(
     analysis_id: str,
     request: GenerateExamRequest,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_db),
 ):
     exam = await exam_service.generate_exam(
         db=db,
@@ -74,7 +72,7 @@ async def generate_exam(
 @router.get("/{exam_id}/download")
 async def download_exam(
     exam_id: str,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_db),
 ):
     exam = await exam_service.get_exam(
         db=db,

--- a/backend/app/services/exam.py
+++ b/backend/app/services/exam.py
@@ -1,7 +1,7 @@
 import json
 import re
 import anthropic
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import ANTHROPIC_API_KEY
 from app.core.errors import AppError, handle_service_error
 from app.repositories import exam as exam_repository
@@ -43,7 +43,7 @@ def parse_claude_response(text: str, code: str) -> dict:
 
 # PDF 바이트에서 텍스트 추출 후 패턴 분석까지 수행 (라우터 진입점)
 async def analyze_exam_from_pdf(
-    db: Session,
+    db: AsyncSession,
     school_name: str,
     pdf_bytes: bytes,
 ) -> ExamAnalysis:
@@ -79,7 +79,7 @@ async def extract_passages_from_pdf(
 
 # 시험 패턴 분석 함수
 async def analyze_exam_pattern(
-    db: Session,
+    db: AsyncSession,
     school_name: str,
     pdf_text: str,
 ) -> ExamAnalysis:
@@ -89,7 +89,7 @@ async def analyze_exam_pattern(
 
         # DB에 이미 분석 결과 있으면 재활용
         # 주의: 동일 학교명 기준 캐싱이므로 연도/버전 구분 없음 (의도된 동작)
-        existing = exam_repository.get_analysis_by_school_name(
+        existing = await exam_repository.get_analysis_by_school_name(
             db=db,
             school_name=normalized_name,
         )
@@ -126,7 +126,7 @@ async def analyze_exam_pattern(
             message.content[0].text,
             code="SERVICE/EXAM/ANALYZE_PARSE_ERROR",
         )
-        return exam_repository.save_analysis(
+        return await exam_repository.save_analysis(
             db=db,
             school_name=normalized_name,
             analysis_result=analysis_result,
@@ -188,14 +188,14 @@ async def extract_passages(
 
 # 시험지 생성 함수
 async def generate_exam(
-    db: Session,
+    db: AsyncSession,
     analysis_id: str,
     passages: dict,
     options: dict,
 ) -> ExamResult:
     try:
         # 분석 결과 조회
-        analysis = exam_repository.get_analysis(
+        analysis = await exam_repository.get_analysis(
             db=db,
             analysis_id=analysis_id,
         )
@@ -236,7 +236,7 @@ async def generate_exam(
         )
 
         # DB 저장
-        return exam_repository.save_exam_result(
+        return await exam_repository.save_exam_result(
             db=db,
             analysis_id=str(analysis.id),
             exam_content=exam_content,
@@ -253,11 +253,11 @@ async def generate_exam(
 
 # 시험지 조회 함수
 async def get_exam(
-    db: Session,
+    db: AsyncSession,
     exam_id: str,
 ) -> ExamResult:
     try:
-        return exam_repository.get_exam_result(
+        return await exam_repository.get_exam_result(
             db=db,
             exam_id=exam_id,
         )

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -1,5 +1,6 @@
+import asyncio
 from logging.config import fileConfig
-from sqlalchemy import engine_from_config
+from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy import pool
 from alembic import context
 import sys
@@ -19,8 +20,12 @@ if config.config_file_name is not None:
 target_metadata = Base.metadata
 
 
+def get_async_url() -> str:
+    return DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://")
+
+
 def run_migrations_offline() -> None:
-    url = DATABASE_URL
+    url = get_async_url()
     context.configure(
         url=url,
         target_metadata=target_metadata,
@@ -31,24 +36,23 @@ def run_migrations_offline() -> None:
         context.run_migrations()
 
 
-def run_migrations_online() -> None:
-    configuration = config.get_section(config.config_ini_section, {})
-    configuration["sqlalchemy.url"] = DATABASE_URL
-
-    connectable = engine_from_config(
-        configuration,
-        prefix="sqlalchemy.",
+async def run_migrations_online() -> None:
+    connectable = create_async_engine(
+        get_async_url(),
         poolclass=pool.NullPool,
     )
-    with connectable.connect() as connection:
-        context.configure(
-            connection=connection, target_metadata=target_metadata
+    async with connectable.connect() as connection:
+        await connection.run_sync(
+            lambda conn: context.configure(
+                connection=conn,
+                target_metadata=target_metadata,
+            )
         )
-        with context.begin_transaction():
-            context.run_migrations()
+        async with connection.begin():
+            await connection.run_sync(lambda conn: context.run_migrations())
 
 
 if context.is_offline_mode():
     run_migrations_offline()
 else:
-    run_migrations_online()
+    asyncio.run(run_migrations_online())

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -31,3 +31,4 @@ tomli==2.4.1
 typing-inspection==0.4.2
 typing_extensions==4.15.0
 uvicorn==0.39.0
+asyncpg==0.30.0


### PR DESCRIPTION
## 변경 사항
- `AsyncSession`으로 전환하여 async 서비스와 동기 DB I/O 혼용 문제 해결
- `dependencies.py` - `create_async_engine` + `async_sessionmaker` 사용
- `repositories/exam.py` - 모든 DB 쿼리 `async/await`으로 전환 (`select()` 사용)
- `services/exam.py` - `AsyncSession` 타입으로 변경, 레포지토리 호출 `await` 추가
- `routers/exam.py` - `AsyncSession` 타입으로 변경
- `migrations/env.py` - async 마이그레이션 지원
- `requirements.txt` - `asyncpg` 추가

## 관련 이슈
close #50