### PR TITLE
refactor: DB 엔진 싱글턴화, ValueError → AppError 교체, 응답 스키마 추가 (#52, #53, …

### DIFF
--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -7,27 +7,24 @@ def get_async_database_url() -> str:
     return DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://")
 
 
-# async engine 생성
-def get_engine():
-    return create_async_engine(
-        get_async_database_url(),
-        echo=False,
-    )
+# 모듈 레벨에서 1회 초기화 (커넥션 풀 재사용)
+engine = create_async_engine(
+    get_async_database_url(),
+    echo=False,
+    pool_size=5,
+    max_overflow=10,
+)
 
-
-# async session factory
-def get_session_local():
-    return async_sessionmaker(
-        bind=get_engine(),
-        class_=AsyncSession,
-        autocommit=False,
-        autoflush=False,
-        expire_on_commit=False,
-    )
+SessionLocal = async_sessionmaker(
+    bind=engine,
+    class_=AsyncSession,
+    autocommit=False,
+    autoflush=False,
+    expire_on_commit=False,
+)
 
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:
-    SessionLocal = get_session_local()
     async with SessionLocal() as session:
         try:
             yield session

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,10 +12,14 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # 서버 시작 시
+    # 서버 시작 시 DB 연결 확인
+    from app.dependencies import engine
+    async with engine.begin() as conn:
+        logger.info("DB 연결 확인 완료")
     logger.info("exam_maker 서버 시작!")
     yield
-    # 서버 종료 시
+    # 서버 종료 시 엔진 정리
+    await engine.dispose()
     logger.info("exam_maker 서버 종료!")
 
 
@@ -46,8 +50,6 @@ ERROR_STATUS_MAP: dict[str, int] = {
 
 
 def get_http_status(code: str) -> int:
-    # 슬래시 계층형 코드에서 마지막 세그먼트 추출
-    # 예: "REPO/EXAM/NOT_FOUND" → "NOT_FOUND" → 404
     last_segment = code.split("/")[-1]
     return ERROR_STATUS_MAP.get(last_segment, 400)
 

--- a/backend/app/routers/exam.py
+++ b/backend/app/routers/exam.py
@@ -6,13 +6,18 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies import get_db
 from app.services import exam as exam_service
 from app.services.docx import create_exam_docx
-from app.schemas.exam import GenerateExamRequest
+from app.schemas.exam import (
+    GenerateExamRequest,
+    AnalyzeExamResponse,
+    ExtractPassagesResponse,
+    GenerateExamResponse,
+)
 
 router = APIRouter(prefix="/api/v1/exam", tags=["exam"])
 
 
 # 시험 패턴 분석
-@router.post("/analyze")
+@router.post("/analyze", response_model=AnalyzeExamResponse)
 async def analyze_exam(
     school_name: str,
     file: UploadFile = File(...),
@@ -24,16 +29,16 @@ async def analyze_exam(
         school_name=school_name,
         pdf_bytes=pdf_bytes,
     )
-    return {
-        "success": True,
-        "analysis_id": str(analysis.id),
-        "analysis_result": analysis.analysis_result,
-        "message": "기출 분석이 완료됐습니다.",
-    }
+    return AnalyzeExamResponse(
+        success=True,
+        analysis_id=str(analysis.id),
+        analysis_result=analysis.analysis_result,
+        message="기출 분석이 완료됐습니다.",
+    )
 
 
 # 시험 범위 본문 추출
-@router.post("/range")
+@router.post("/range", response_model=ExtractPassagesResponse)
 async def extract_exam_range(
     files: List[UploadFile] = File(...),
 ):
@@ -42,14 +47,14 @@ async def extract_exam_range(
         pdf_bytes = await file.read()
         passages = await exam_service.extract_passages_from_pdf(pdf_bytes=pdf_bytes)
         all_passages.update(passages)
-    return {
-        "success": True,
-        "passages": all_passages,
-    }
+    return ExtractPassagesResponse(
+        success=True,
+        passages=all_passages,
+    )
 
 
 # 시험지 생성
-@router.post("/generate")
+@router.post("/generate", response_model=GenerateExamResponse)
 async def generate_exam(
     analysis_id: str,
     request: GenerateExamRequest,
@@ -61,11 +66,11 @@ async def generate_exam(
         passages=request.passages.dict(),
         options=request.options.dict(),
     )
-    return {
-        "success": True,
-        "exam_id": str(exam.id),
-        "exam": exam.exam_content,
-    }
+    return GenerateExamResponse(
+        success=True,
+        exam_id=str(exam.id),
+        exam=exam.exam_content,
+    )
 
 
 # 시험지 docx 다운로드

--- a/backend/app/schemas/exam.py
+++ b/backend/app/schemas/exam.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import Optional, List, Any
 from pydantic import BaseModel
 
 
@@ -23,3 +23,31 @@ class ExamOptions(BaseModel):
 class GenerateExamRequest(BaseModel):
     passages: PassagesRequest
     options: ExamOptions
+
+
+# 응답 스키마
+class AnalyzeExamResponse(BaseModel):
+    success: bool
+    analysis_id: str
+    analysis_result: dict[str, Any]
+    message: str
+
+
+class ExtractPassagesResponse(BaseModel):
+    success: bool
+    passages: dict[str, Any]
+
+
+class GenerateExamResponse(BaseModel):
+    success: bool
+    exam_id: str
+    exam: dict[str, Any]
+
+
+class DownloadExamResponse(BaseModel):
+    success: bool
+    exam_id: str
+
+
+class HealthResponse(BaseModel):
+    status: str

--- a/backend/app/services/exam.py
+++ b/backend/app/services/exam.py
@@ -96,9 +96,13 @@ async def analyze_exam_pattern(
         if existing:
             return existing
 
-        # PDF 텍스트가 비어있으면 비즈니스 예외 발생
+        # PDF 텍스트가 비어있으면 사용자 입력 오류로 처리
         if not pdf_text or not pdf_text.strip():
-            raise ValueError("PDF에서 텍스트를 추출할 수 없습니다.")
+            raise AppError(
+                source="service",
+                code="SERVICE/EXAM/EMPTY_PDF",
+                message="PDF에서 텍스트를 추출할 수 없습니다.",
+            )
 
         client = get_anthropic_client()
 
@@ -146,9 +150,13 @@ async def extract_passages(
     pdf_text: str,
 ) -> dict:
     try:
-        # PDF 텍스트가 비어있으면 비즈니스 예외 발생
+        # PDF 텍스트가 비어있으면 사용자 입력 오류로 처리
         if not pdf_text or not pdf_text.strip():
-            raise ValueError("PDF에서 텍스트를 추출할 수 없습니다.")
+            raise AppError(
+                source="service",
+                code="SERVICE/EXAM/EMPTY_PDF",
+                message="PDF에서 텍스트를 추출할 수 없습니다.",
+            )
 
         client = get_anthropic_client()
 
@@ -200,9 +208,13 @@ async def generate_exam(
             analysis_id=analysis_id,
         )
 
-        # 지문이 비어있으면 비즈니스 예외 발생
+        # 지문이 비어있으면 사용자 입력 오류로 처리
         if not passages:
-            raise ValueError("시험 범위 지문이 없습니다.")
+            raise AppError(
+                source="service",
+                code="SERVICE/EXAM/EMPTY_PASSAGES",
+                message="시험 범위 지문이 없습니다.",
+            )
 
         client = get_anthropic_client()
 


### PR DESCRIPTION
## 변경 사항
- `dependencies.py` - 엔진/세션팩토리 모듈 레벨 1회 초기화 (커넥션 풀 재사용)
- `main.py` - lifespan에서 DB 연결 확인 및 종료 시 엔진 dispose
- `services/exam.py` - `ValueError` → `AppError`로 교체 (도메인 예외 일관성)
- `schemas/exam.py` - 응답 스키마 추가 (`AnalyzeExamResponse`, `ExtractPassagesResponse`, `GenerateExamResponse`)
- `routers/exam.py` - `response_model` 추가

## 관련 이슈
close #52
close #53
close #54