### PR TITLE
refactor: 환경변수 유효성 검사, Anthropic 싱글턴, Form 파라미터 수정 (#56)

### DIFF
--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,6 +1,8 @@
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
 from typing import AsyncGenerator
-from app.core.config import DATABASE_URL
+import anthropic
+from app.core.config import DATABASE_URL, ANTHROPIC_API_KEY
+
 
 # PostgreSQL async URL로 변환 (postgresql:// → postgresql+asyncpg://)
 def get_async_database_url() -> str:
@@ -22,6 +24,9 @@ SessionLocal = async_sessionmaker(
     autoflush=False,
     expire_on_commit=False,
 )
+
+# Anthropic 클라이언트 싱글턴 (HTTP 커넥션 풀 재사용)
+anthropic_client = anthropic.AsyncAnthropic(api_key=ANTHROPIC_API_KEY)
 
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:

--- a/backend/app/routers/exam.py
+++ b/backend/app/routers/exam.py
@@ -1,6 +1,6 @@
 import io
 from typing import List
-from fastapi import APIRouter, UploadFile, File, Depends
+from fastapi import APIRouter, UploadFile, File, Depends, Form
 from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies import get_db
@@ -19,7 +19,7 @@ router = APIRouter(prefix="/api/v1/exam", tags=["exam"])
 # 시험 패턴 분석
 @router.post("/analyze", response_model=AnalyzeExamResponse)
 async def analyze_exam(
-    school_name: str,
+    school_name: str = Form(...),
     file: UploadFile = File(...),
     db: AsyncSession = Depends(get_db),
 ):

--- a/backend/app/services/exam.py
+++ b/backend/app/services/exam.py
@@ -2,16 +2,12 @@ import json
 import re
 import anthropic
 from sqlalchemy.ext.asyncio import AsyncSession
-from app.core.config import ANTHROPIC_API_KEY
 from app.core.errors import AppError, handle_service_error
 from app.repositories import exam as exam_repository
 from app.prompts.exam import ANALYZE_SCHOOL_PROMPT, EXTRACT_PASSAGES_PROMPT, get_generate_exam_prompt
 from app.utils.pdf import extract_pdf_text
 from app.models.exam import ExamAnalysis, ExamResult
-
-
-def get_anthropic_client() -> anthropic.AsyncAnthropic:
-    return anthropic.AsyncAnthropic(api_key=ANTHROPIC_API_KEY)
+from app.dependencies import anthropic_client
 
 
 # JSON 코드블록 제거 유틸
@@ -89,6 +85,7 @@ async def analyze_exam_pattern(
 
         # DB에 이미 분석 결과 있으면 재활용
         # 주의: 동일 학교명 기준 캐싱이므로 연도/버전 구분 없음 (의도된 동작)
+        # 향후 개선: (school_name, year) 복합 키로 확장 가능
         existing = await exam_repository.get_analysis_by_school_name(
             db=db,
             school_name=normalized_name,
@@ -104,11 +101,9 @@ async def analyze_exam_pattern(
                 message="PDF에서 텍스트를 추출할 수 없습니다.",
             )
 
-        client = get_anthropic_client()
-
         try:
             # Claude Sonnet으로 출제 패턴 분석
-            message = await client.messages.create(
+            message = await anthropic_client.messages.create(
                 model="claude-sonnet-4-5",
                 max_tokens=2000,
                 messages=[
@@ -158,11 +153,9 @@ async def extract_passages(
                 message="PDF에서 텍스트를 추출할 수 없습니다.",
             )
 
-        client = get_anthropic_client()
-
         try:
             # Claude Haiku로 순수 본문 추출 (듣기 제외)
-            message = await client.messages.create(
+            message = await anthropic_client.messages.create(
                 model="claude-haiku-4-5",
                 max_tokens=8000,
                 messages=[
@@ -216,11 +209,9 @@ async def generate_exam(
                 message="시험 범위 지문이 없습니다.",
             )
 
-        client = get_anthropic_client()
-
         try:
             # Claude Opus로 시험지 생성
-            message = await client.messages.create(
+            message = await anthropic_client.messages.create(
                 model="claude-opus-4-5",
                 max_tokens=16000,
                 messages=[


### PR DESCRIPTION
## 변경 사항
- `config.py` - 필수 환경변수 누락 시 즉시 실패 (fail-fast)
- `dependencies.py` - Anthropic 클라이언트 모듈 레벨 싱글턴화 (HTTP 커넥션 풀 재사용)
- `services/exam.py` - `get_anthropic_client()` 제거, 싱글턴 클라이언트 사용
- `services/exam.py` - 캐싱 전략 주석 보강 (향후 복합 키 확장 계획 명시)
- `routers/exam.py` - `school_name` query parameter → `Form` 파라미터로 수정

## 관련 이슈
close #56