### PR TITLE
fix: school_name query parameter → form data로 수정 (#58)

### DIFF
--- a/frontend/services/examService.ts
+++ b/frontend/services/examService.ts
@@ -10,9 +10,10 @@ export async function analyzeExam({
 }) {
   const formData = new FormData()
   formData.append('file', file)
+  formData.append('school_name', schoolName)  // query parameter → form data로 변경
 
   const response = await fetch(
-    `${BASE_URL}/api/v1/exam/analyze?school_name=${encodeURIComponent(schoolName)}`,
+    `${BASE_URL}/api/v1/exam/analyze`,  // query string 제거
     {
       method: 'POST',
       body: formData,


### PR DESCRIPTION
## 변경 사항
- `examService.ts` - `school_name`을 query parameter에서 form data로 변경
- 백엔드 `Form(...)` 파라미터와 일치하도록 수정

## 관련 이슈
close #58